### PR TITLE
[add] livedata 지원 

### DIFF
--- a/app/src/main/java/com/kdjj/validator/data/User.kt
+++ b/app/src/main/java/com/kdjj/validator/data/User.kt
@@ -1,5 +1,7 @@
 package com.kdjj.validator.data
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.kdjj.validation_annotation.annotation.*
 
 
@@ -24,5 +26,10 @@ data class User (
 
     @MinLong(5L)
     @MaxLong(100L)
-    val speed: Long
+    val speed: Long,
+
+
+    @MinLong(4L)
+    val mutableLiveData: MutableLiveData<Long>,
+    val liveData: LiveData<String>,
 )

--- a/validation_annotation/build.gradle
+++ b/validation_annotation/build.gradle
@@ -16,7 +16,7 @@ afterEvaluate {
                 from components.java
                 groupId = 'com.kdjj.validation_annotation'
                 artifactId = 'validation_annotation'
-                version = '0.0.2'
+                version = '0.0.3'
             }
         }
     }

--- a/validation_annotation_processor/build.gradle
+++ b/validation_annotation_processor/build.gradle
@@ -23,7 +23,7 @@ afterEvaluate {
                 from components.java
                 groupId = 'com.kdjj.validation_annotation_processor'
                 artifactId = 'validation_annotation_processor'
-                version = '0.0.2'
+                version = '0.0.3'
             }
         }
     }


### PR DESCRIPTION
## 개요
Issue : https://github.com/Jeong-heon2/Validator/issues/2

## 발생한 이슈
nullable 프로퍼티에 대한 처리가 필요함 .
```kotlin
  public fun validateUser(user: User): Boolean {
    if(validateName(user.name!!) && validateAge(user.age!!) && validateLuck(user.luck!!) &&
        validatePower(user.power!!) && validateSpeed(user.speed!!) &&
        validateMutableLiveData(user.mutableLiveData.value!!)) {
      return true
    }
    return false
  }
```
AnotationProcessr 에서 String?, String 타입을 구분할 수 없는 문제가 있음 
우선은 !! 로 처리.
추후에 @ Nullable , @ NonNull 어노테이션을 추가로 지원해야 할 것 같음 